### PR TITLE
Make sure heartbeats are sent regularly to keep the TCP connection open

### DIFF
--- a/cosmicpi-daq.py
+++ b/cosmicpi-daq.py
@@ -483,7 +483,7 @@ def main():
             # Process Arduino data json strings
 
             rc = ser.readline()
-
+            sio.connection.process_data_events()
 
             if len(rc) == 0:
                 print ("Serial input buffer empty")


### PR DESCRIPTION
Fixes an issue where the broker closes the TCP connection if no events were published during the default heartbeat interval (60s)
