### PR TITLE
Enhanced CLI, added USB toggle

### DIFF
--- a/cosmicpi/cli.py
+++ b/cosmicpi/cli.py
@@ -1,65 +1,139 @@
 #!/usr/bin/env python
 
-import argparse
+import logging
 import socket
 import sys
 
+import time
+from cliff.app import App
+from cliff.command import Command
+from cliff.commandmanager import CommandManager
+from blessings import Terminal
 
-def main():
-    parser = argparse.ArgumentParser(description='Interact with a running CosmicPi detector.')
-    subparsers = parser.add_subparsers(dest='command', help='available commands')
 
-    subparsers.add_parser('s', help='show the status of the detector')
-    subparsers.add_parser('d', help='toggle debug output')
-    subparsers.add_parser('l', help='toggle event logging')
-    subparsers.add_parser('n', help='toggle cosmic event sending')
-    subparsers.add_parser('w', help='toggle weather event sending')
-    subparsers.add_parser('v', help='toggle vibration event sending')
+class SocketCommand(object):
 
-    arduino_parser = subparsers.add_parser('arduino', help='send commands to the arduino board')
-    arduino_subparsers = arduino_parser.add_subparsers(dest='arduino_command', help='available arduino commands')
+    @staticmethod
+    def send_and_receive(command):
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 
-    arduino_subparsers.add_parser('HTUX', help='reset the HTH chip')
-    arduino_subparsers.add_parser('HTUD', help='HTU Temperature-Humidity display rate') \
-        .add_argument('value', type=int, help='display rate value to set')
-    arduino_subparsers.add_parser('BMPD', help='BMP Temperature-Altitude display rate') \
-        .add_argument('value', type=int, help='display rate value to set')
-    arduino_subparsers.add_parser('LOCD', help='Location latitude-longitude display rate') \
-        .add_argument('value', type=int, help='display rate value to set')
-    arduino_subparsers.add_parser('TIMD', help='Timing uptime-frequency-etm display rate') \
-        .add_argument('value', type=int, help='display rate value to set')
-    arduino_subparsers.add_parser('STSD', help='Status info display rate') \
-        .add_argument('value', type=int, help='display rate value to set')
-    arduino_subparsers.add_parser('EVQT', help='Event queue dump threshold') \
-        .add_argument('value', type=int, help='threshold value to set (1..32)')
-    arduino_subparsers.add_parser('ACLD', help='Accelerometer display rate') \
-        .add_argument('value', type=int, help='display rate value to set')
-    arduino_subparsers.add_parser('MAGD', help='Magnetometer display rate') \
-        .add_argument('value', type=int, help='display rate value to set')
-    arduino_subparsers.add_parser('ACLT', help='Accelerometer event trigger threshold') \
-        .add_argument('value', type=int, help='threshold value to set (0..127')
+        try:
+            sock.connect("/tmp/cosmicpi.sock")
+        except:
+            print ("Fatal: Couldn't connect, is the process running?")
+            sys.exit(1)
 
-    args = parser.parse_args()
+        sock.send(command)
+        response = sock.recv(1024)
+        sock.close()
+        return response
 
-    command = args.command
 
-    if 'arduino_command' in args:
-        command += ' ' + args.arduino_command
-        command += ' ' + str(args.value) if hasattr(args, 'value') else ''
+class UsbToggle(Command, SocketCommand):
+    """Toggle the USB ebabled/disabled state."""
+    def take_action(self, args):
+        self.app.stdout.write(self.send_and_receive('u') + '\n')
 
-    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 
-    try:
-        s.connect("/tmp/cosmicpi.sock")
-    except:
-        print ("Fatal: Couldn't connect, is the process running?")
-        sys.exit(1)
+class Arduino(Command, SocketCommand):
+    """Send commands to the Arduino firmware."""
 
-    s.send(command)
-    response = s.recv(1024)
+    def get_parser(self, prog_name):
+        parser = super(Arduino, self).get_parser(prog_name)
 
-    s.close()
-    print(str(response))
+        subparsers = parser.add_subparsers(dest='arduino_command', help='available arduino commands')
+
+        subparsers.add_parser('HTUX', help='reset the HTH chip')
+        subparsers.add_parser('HTUD', help='HTU Temperature-Humidity display rate') \
+            .add_argument('value', type=int, help='display rate value to set')
+        subparsers.add_parser('BMPD', help='BMP Temperature-Altitude display rate') \
+            .add_argument('value', type=int, help='display rate value to set')
+        subparsers.add_parser('LOCD', help='Location latitude-longitude display rate') \
+            .add_argument('value', type=int, help='display rate value to set')
+        subparsers.add_parser('TIMD', help='Timing uptime-frequency-etm display rate') \
+            .add_argument('value', type=int, help='display rate value to set')
+        subparsers.add_parser('STSD', help='Status info display rate') \
+            .add_argument('value', type=int, help='display rate value to set')
+        subparsers.add_parser('EVQT', help='Event queue dump threshold') \
+            .add_argument('value', type=int, help='threshold value to set (1..32)')
+        subparsers.add_parser('ACLD', help='Accelerometer display rate') \
+            .add_argument('value', type=int, help='display rate value to set')
+        subparsers.add_parser('MAGD', help='Magnetometer display rate') \
+            .add_argument('value', type=int, help='display rate value to set')
+        subparsers.add_parser('ACLT', help='Accelerometer event trigger threshold') \
+            .add_argument('value', type=int, help='threshold value to set (0..127)')
+
+        return parser
+
+    def take_action(self, args):
+        command = args.arduino_command + (' ' + str(args.value) if hasattr(args, 'value') else '')
+        self.app.stdout.write(self.send_and_receive('arduino ' + command) + '\n')
+
+
+class Status(Command, SocketCommand):
+    """Show the current status of the detector."""
+
+    def get_parser(self, prog_name):
+        parser = super(Status, self).get_parser(prog_name)
+        parser.add_argument('-m', '--monitor', action='store_true',
+                            help='monitor the detector status continuously')
+        return parser
+
+    def take_action(self, args):
+        if args.monitor:
+            term = Terminal()
+
+            while True:
+                try:
+                    status = self.get_status()
+                    self.app.stdout.write(status)
+                    self.app.stdout.write(term.move_y(term.height - len(status.split('\n'))))
+                    time.sleep(1)
+                except KeyboardInterrupt:
+                    self.app.stdout.write(term.move_y(term.height) + '\n')
+                    return
+        else:
+            self.app.stdout.write(self.get_status() + '\n')
+
+    def get_status(self):
+        return self.send_and_receive('s')
+
+
+class Cli(App):
+    NAME = 'cosmicpi'
+    log = logging.getLogger(__name__)
+
+    def __init__(self):
+        command = CommandManager('cosmicpi')
+        super(Cli, self).__init__(
+            description='CosmicPi command line interface',
+            version='0.0.1',
+            command_manager=command,
+        )
+        commands = {
+            'status': Status,
+            'usb_toggle': UsbToggle,
+            'arduino': Arduino
+        }
+        for k, v in commands.iteritems():
+            command.add_command(k, v)
+
+    def initialize_app(self, argv):
+        self.log.debug('initialize_app')
+
+    def prepare_to_run_command(self, cmd):
+        self.log.debug('prepare_to_run_command %s', cmd.__class__.__name__)
+
+    def clean_up(self, cmd, result, err):
+        self.log.debug('clean_up %s', cmd.__class__.__name__)
+        if err:
+            self.log.debug('got an error: %s', err)
+
+
+def main(argv=sys.argv[1:]):
+    cli = Cli()
+    return cli.run(argv)
+
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main(sys.argv[1:]))

--- a/cosmicpi/command_handler.py
+++ b/cosmicpi/command_handler.py
@@ -113,6 +113,13 @@ class CommandHandler(object):
                     response += ("WeatherStation: Flag:%s\n" % (self.options.monitoring['weather']))
                     response += ("Events........: Sent:%d LogFlag:%s\n" % (self.detector.events, self.options.logging['enabled']))
 
+                elif cmd == 'u':
+                    if self.usb.enabled:
+                        self.usb.disable()
+                    else:
+                        self.usb.enable()
+                    response = ("USB: %s" % ('enabled' if self.usb.enabled else 'disabled'))
+
                 elif cmd == 'n':
                     if self.options.broker['enabled']:
                         self.options.broker['enabled'] = False

--- a/cosmicpi/usb_handler.py
+++ b/cosmicpi/usb_handler.py
@@ -13,6 +13,7 @@ class UsbHandler(object):
         self.baudrate = baudrate
         self.timeout  = timeout
         self.is_open = False
+        self.enabled = True
 
     def open(self):
         self.usb = serial.Serial(port=self.usbdev, baudrate=self.baudrate, timeout=self.timeout)
@@ -23,10 +24,26 @@ class UsbHandler(object):
         self.is_open = True
 
     def close(self):
-        self.usb.close()
+        try:
+            self.usb.close()
+        except:
+            pass
         self.is_open = False
 
+    def enable(self):
+        self.enabled = True
+        log.info("Enabling serial port")
+
+    def disable(self):
+        self.enabled = False
+        log.info("Disabling serial port")
+        self.close()
+
     def readline(self):
+        if not self.enabled:
+            time.sleep(1)
+            return ''
+
         if not self.is_open:
             try:
                 self.open()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     include_package_data=True,
-    install_requires=['pika', 'netifaces'],
+    install_requires=['pika', 'netifaces', 'blessings', 'cliff'],
     entry_points={
         "console_scripts": {
             "cosmicpi = cosmicpi:main",


### PR DESCRIPTION
- If you run `cli.py` with no arguments, it will drop into an interactive shell.
- You can monitor the detector status by typing `status --monitor`.
- You can enable and disable the USB connection with the `usb_toggle` command.
- Note that the `blessings` and `cliff` libraries need to be installed.
